### PR TITLE
Lock gulp-sass version at 1.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "gulp-imagemin": "^0.6.2",
     "gulp-minify-css": "^0.3.11",
     "gulp-notify": "^1.4.2",
-    "gulp-sass": "^1.1.0",
+    "gulp-sass": "1.2.4",
     "gulp-sourcemaps": "^1.2.8",
     "gulp-uglify": "^1.0.2",
     "gulp-util": "^3.0.0",


### PR DESCRIPTION
Breaking changes in later versions prevent sass syntax from working correctly. 

See: https://github.com/dlmanning/gulp-sass/issues/173

Will update when gulp-sass issues are addressed.

Fixes #76 