### PR TITLE
Versioned bundles support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,13 @@
 build
 Desktop.ini
 node_modules
+
+bower_components
+
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm
+*.iml
+## Directory-based project format:
+.idea/
+## File-based project format:
+*.ipr
+*.iws

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Includes the following tools, tasks, and workflows:
 - Shimming non common-js vendor code with other dependencies (like a jQuery plugin)
 - *New* Multiple bundles with shared dependencies
 - *New* Separate compression task for production builds
+- *New* Support for versioned bundles via gulp-html-replace (version your app bundle to make use of web caching)
 
 If you've never used Node or npm before, you'll need to install Node.
 If you use homebrew, do:

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -1,5 +1,6 @@
 var dest = "./build";
 var src = './src';
+var project = require('package.json');
 
 module.exports = {
   browserSync: {
@@ -20,6 +21,12 @@ module.exports = {
     src: src + "/images/**",
     dest: dest + "/images"
   },
+  htmlreplace: {
+    page: {
+      src: project.version,
+      tpl: '<script src="page-%s.js"></script>'
+    }
+  },
   markup: {
     src: src + "/htdocs/**",
     dest: dest
@@ -38,7 +45,7 @@ module.exports = {
     }, {
       entries: src + '/javascript/page.js',
       dest: dest,
-      outputName: 'page.js',
+      outputName: 'page-' + project.version + ".js",
       // list of externally available modules to exclude from the bundle
       external: ['jquery', 'underscore']
     }]

--- a/gulp/tasks/markup.js
+++ b/gulp/tasks/markup.js
@@ -1,9 +1,12 @@
 var gulp = require('gulp');
-var config = require('../config').markup
+var config = require('../config');
+var markup = config.markup;
+var htmlreplace = require('gulp-html-replace');
 var browserSync  = require('browser-sync');
 
 gulp.task('markup', function() {
-  return gulp.src(config.src)
-    .pipe(gulp.dest(config.dest))
+  return gulp.src(markup.src)
+    .pipe(htmlreplace(config.htmlreplace))
+    .pipe(gulp.dest(markup.dest))
     .pipe(browserSync.reload({stream:true}));
 });

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "gulp-autoprefixer": "^2.0.0",
     "gulp-changed": "^0.4.1",
     "gulp-filesize": "0.0.6",
+    "gulp-html-replace": "^1.4.3",
     "gulp-imagemin": "^0.6.2",
     "gulp-minify-css": "^0.3.11",
     "gulp-notify": "^1.4.2",

--- a/src/htdocs/index.html
+++ b/src/htdocs/index.html
@@ -11,6 +11,8 @@
     <h1>Gulp All The Things!</h1>
     <div id="content"></div>
     <script src="global.js"></script>
+    <!-- build:page -->
     <script src="page.js"></script>
+    <!-- endbuild -->
   </body>
 </html>


### PR DESCRIPTION
* added support for versioned bundels loading via gulp-html-replace
* updated markup task to include gulp-html-replace
* configuration is specified as htmlreplace object in config.js