### PR TITLE
Watch for newly created/deleted files

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -1,4 +1,4 @@
-var dest = "./build";
+var dest = './build';
 var src = './src';
 
 module.exports = {
@@ -9,7 +9,7 @@ module.exports = {
     }
   },
   sass: {
-    src: src + "/sass/*.{sass,scss}",
+    src: src + '/sass/*.{sass,scss}',
     dest: dest,
     settings: {
       indentedSyntax: true, // Enable .sass syntax!
@@ -17,18 +17,18 @@ module.exports = {
     }
   },
   images: {
-    src: src + "/images/**",
-    dest: dest + "/images"
+    src: src + '/images/**',
+    dest: dest + '/images'
   },
   markup: {
-    src: src + "/htdocs/**",
+    src: src + '/htdocs/**',
     dest: dest
   },
   browserify: {
     // A separate bundle will be generated for each
     // bundle config in the list below
     bundleConfigs: [{
-      entries: src + '/javascript/global.coffee',
+      entries: './' + src + '/javascript/global.coffee',
       dest: dest,
       outputName: 'global.js',
       // Additional file extentions to make optional
@@ -36,7 +36,7 @@ module.exports = {
       // list of modules to make require-able externally
       require: ['jquery', 'underscore']
     }, {
-      entries: src + '/javascript/page.js',
+      entries: './' + src + '/javascript/page.js',
       dest: dest,
       outputName: 'page.js',
       // list of externally available modules to exclude from the bundle

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -1,5 +1,5 @@
-var dest = './build';
-var src = './src';
+var dest = 'build';
+var src = 'src';
 
 module.exports = {
   browserSync: {

--- a/gulp/tasks/images.js
+++ b/gulp/tasks/images.js
@@ -1,8 +1,8 @@
-var changed    = require('gulp-changed');
-var gulp       = require('gulp');
-var imagemin   = require('gulp-imagemin');
-var config     = require('../config').images;
-var browserSync  = require('browser-sync');
+var changed     = require('gulp-changed');
+var gulp        = require('gulp');
+var imagemin    = require('gulp-imagemin');
+var config      = require('../config').images;
+var browserSync = require('browser-sync');
 
 gulp.task('images', function() {
   return gulp.src(config.src)

--- a/gulp/tasks/markup.js
+++ b/gulp/tasks/markup.js
@@ -1,5 +1,5 @@
 var gulp        = require('gulp');
-var config      = require('../config').markup
+var config      = require('../config').markup;
 var browserSync = require('browser-sync');
 
 gulp.task('markup', function() {

--- a/gulp/tasks/markup.js
+++ b/gulp/tasks/markup.js
@@ -1,6 +1,6 @@
-var gulp = require('gulp');
-var config = require('../config').markup
-var browserSync  = require('browser-sync');
+var gulp        = require('gulp');
+var config      = require('../config').markup
+var browserSync = require('browser-sync');
 
 gulp.task('markup', function() {
   return gulp.src(config.src)

--- a/gulp/tasks/minifyCss.js
+++ b/gulp/tasks/minifyCss.js
@@ -8,4 +8,4 @@ gulp.task('minifyCss', ['sass'], function() {
     .pipe(minifyCSS({keepBreaks:true}))
     .pipe(gulp.dest(config.dest))
     .pipe(size());
-})
+});

--- a/gulp/tasks/uglifyJs.js
+++ b/gulp/tasks/uglifyJs.js
@@ -1,6 +1,6 @@
-var gulp    = require('gulp');
-var config  = require('../config').production;
-var size    = require('gulp-filesize');
+var gulp   = require('gulp');
+var config = require('../config').production;
+var size   = require('gulp-filesize');
 var uglify = require('gulp-uglify');
 
 gulp.task('uglifyJs', ['browserify'], function() {

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -5,8 +5,8 @@
 
 var gulp     = require('gulp');
 var config   = require('../config');
-var watchify = require('./browserify')
-var watch    = require('gulp-watch')
+var watchify = require('./browserify');
+var watch    = require('gulp-watch');
 
 gulp.task('watch', ['watchify', 'browserSync'], function(callback) {
   watch(config.sass.src, gulp.start('sass'));

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -11,6 +11,6 @@ var watch    = require('gulp-watch')
 gulp.task('watch', ['watchify', 'browserSync'], function(callback) {
   watch(config.sass.src, gulp.start('sass'));
   watch(config.images.src, gulp.start('images'));
-  watch(config.markup.watch, gulp.start('markup'));
+  watch(config.markup.src, gulp.start('markup'));
   // Watchify will watch and recompile our JS, so no need to gulp.watch it
 });

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -6,10 +6,11 @@
 var gulp     = require('gulp');
 var config   = require('../config');
 var watchify = require('./browserify')
+var watch    = require('gulp-watch')
 
-gulp.task('watch', ['watchify','browserSync'], function(callback) {
-  gulp.watch(config.sass.src,   ['sass']);
-  gulp.watch(config.images.src, ['images']);
-  gulp.watch(config.markup.src, ['markup']);
+gulp.task('watch', ['watchify', 'browserSync'], function(callback) {
+  watch(config.sass.src, gulp.start('sass'));
+  watch(config.images.src, gulp.start('images'));
+  watch(config.markup.watch, gulp.start('markup'));
   // Watchify will watch and recompile our JS, so no need to gulp.watch it
 });

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -9,8 +9,14 @@ var watchify = require('./browserify');
 var watch    = require('gulp-watch');
 
 gulp.task('watch', ['watchify', 'browserSync'], function(callback) {
-  watch(config.sass.src, gulp.start('sass'));
-  watch(config.images.src, gulp.start('images'));
-  watch(config.markup.src, gulp.start('markup'));
+  watch(config.sass.src, function(){
+    gulp.start('sass')
+  });
+  watch(config.images.src, function(){
+    gulp.start('images')
+  });
+  watch(config.markup.src, function(){
+    gulp.start('markup')
+  });
   // Watchify will watch and recompile our JS, so no need to gulp.watch it
 });

--- a/gulp/tasks/watchify.js
+++ b/gulp/tasks/watchify.js
@@ -1,5 +1,5 @@
 var gulp           = require('gulp');
-var browserifyTask = require('./browserify')
+var browserifyTask = require('./browserify');
 
 gulp.task('watchify', function(callback) {
   // Start browserify task with devMode === true

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "gulp-sourcemaps": "^1.2.8",
     "gulp-uglify": "^1.0.2",
     "gulp-util": "^3.0.0",
+    "gulp-watch": "^4.0.1",
     "handlebars": "^1.3.0",
     "hbsfy": "~2.0.0",
     "lodash": "^2.4.1",


### PR DESCRIPTION
One pain-point of using `gulp.watch` is it's inability to recognize newly created/deleted files. This PR updates the watch task to use [gulp-watch](https://github.com/floatdrop/gulp-watch/), which does.

This also aligns some dependencies, adds consistent use of semicolons and single quotes, and corrects a path issue that comes up when leading with a `./`... although, browserify wants them :confused: .. maybe should've been done in another PR. OH WELL.