### PR TITLE
module.exports each task so they can be called as functions

### DIFF
--- a/gulp/tasks/browserSync.js
+++ b/gulp/tasks/browserSync.js
@@ -1,7 +1,10 @@
-var browserSync = require('browser-sync');
-var gulp        = require('gulp');
-var config      = require('../config').browserSync;
+var browserSync = require('browser-sync')
+var gulp        = require('gulp')
+var config      = require('../config').browserSync
 
-gulp.task('browserSync', function() {
-  browserSync(config);
-});
+var browserSyncTask = function() {
+  browserSync(config)
+}
+
+gulp.task('browserSync', browserSyncTask)
+module.exports = browserSyncTask

--- a/gulp/tasks/images.js
+++ b/gulp/tasks/images.js
@@ -1,13 +1,16 @@
-var changed    = require('gulp-changed');
-var gulp       = require('gulp');
-var imagemin   = require('gulp-imagemin');
-var config     = require('../config').images;
-var browserSync  = require('browser-sync');
+var changed     = require('gulp-changed')
+var gulp        = require('gulp')
+var imagemin    = require('gulp-imagemin')
+var config      = require('../config').images
+var browserSync = require('browser-sync')
 
-gulp.task('images', function() {
+var imageTask = function() {
   return gulp.src(config.src)
     .pipe(changed(config.dest)) // Ignore unchanged files
     .pipe(imagemin()) // Optimize
     .pipe(gulp.dest(config.dest))
-    .pipe(browserSync.reload({stream:true}));
-});
+    .pipe(browserSync.reload({stream:true}))
+}
+
+gulp.task('images', imageTask)
+module.exports = imageTask

--- a/gulp/tasks/markup.js
+++ b/gulp/tasks/markup.js
@@ -1,9 +1,12 @@
-var gulp = require('gulp');
-var config = require('../config').markup
-var browserSync  = require('browser-sync');
+var gulp        = require('gulp')
+var config      = require('../config').markup
+var browserSync = require('browser-sync')
 
-gulp.task('markup', function() {
+var markupTask = function() {
   return gulp.src(config.src)
     .pipe(gulp.dest(config.dest))
-    .pipe(browserSync.reload({stream:true}));
-});
+    .pipe(browserSync.reload({stream:true}))
+}
+
+gulp.task('markup', markupTask)
+module.exports = markupTask

--- a/gulp/tasks/minifyCss.js
+++ b/gulp/tasks/minifyCss.js
@@ -1,11 +1,14 @@
-var gulp      = require('gulp');
-var config    = require('../config').production;
-var minifyCSS = require('gulp-minify-css');
-var size      = require('gulp-filesize');
+var gulp      = require('gulp')
+var config    = require('../config').production
+var minifyCSS = require('gulp-minify-css')
+var size      = require('gulp-filesize')
 
-gulp.task('minifyCss', ['sass'], function() {
+var minifyCssTask = function() {
   return gulp.src(config.cssSrc)
     .pipe(minifyCSS({keepBreaks:true}))
     .pipe(gulp.dest(config.dest))
-    .pipe(size());
-})
+    .pipe(size())
+}
+
+gulp.task('minifyCss', ['sass'], minifyCssTask)
+module.exports = minifyCssTask

--- a/gulp/tasks/sass.js
+++ b/gulp/tasks/sass.js
@@ -1,12 +1,12 @@
-var gulp         = require('gulp');
-var browserSync  = require('browser-sync');
-var sass         = require('gulp-sass');
-var sourcemaps   = require('gulp-sourcemaps');
-var handleErrors = require('../util/handleErrors');
-var config       = require('../config').sass;
-var autoprefixer = require('gulp-autoprefixer');
+var gulp         = require('gulp')
+var browserSync  = require('browser-sync')
+var sass         = require('gulp-sass')
+var sourcemaps   = require('gulp-sourcemaps')
+var handleErrors = require('../util/handleErrors')
+var config       = require('../config').sass
+var autoprefixer = require('gulp-autoprefixer')
 
-gulp.task('sass', function () {
+var sassTask = function () {
   return gulp.src(config.src)
     .pipe(sourcemaps.init())
     .pipe(sass(config.settings))
@@ -14,5 +14,8 @@ gulp.task('sass', function () {
     .pipe(sourcemaps.write())
     .pipe(autoprefixer({ browsers: ['last 2 version'] }))
     .pipe(gulp.dest(config.dest))
-    .pipe(browserSync.reload({stream:true}));
-});
+    .pipe(browserSync.reload({stream:true}))
+}
+
+gulp.task('sass', sassTask)
+module.exports = sassTask

--- a/gulp/tasks/uglifyJs.js
+++ b/gulp/tasks/uglifyJs.js
@@ -1,11 +1,14 @@
-var gulp    = require('gulp');
-var config  = require('../config').production;
-var size    = require('gulp-filesize');
-var uglify = require('gulp-uglify');
+var gulp    = require('gulp')
+var config  = require('../config').production
+var size    = require('gulp-filesize')
+var uglify  = require('gulp-uglify')
 
-gulp.task('uglifyJs', ['browserify'], function() {
+var uglifyTask = function() {
   return gulp.src(config.jsSrc)
     .pipe(uglify())
     .pipe(gulp.dest(config.dest))
-    .pipe(size());
-});
+    .pipe(size())
+}
+
+gulp.task('uglifyJs', ['browserify'], uglifyTask)
+module.exports = uglifyTask

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -3,13 +3,16 @@
    - gulp/tasks/browserSync.js watches and reloads compiled files
 */
 
-var gulp     = require('gulp');
-var config   = require('../config');
+var gulp     = require('gulp')
+var config   = require('../config')
 var watchify = require('./browserify')
 
-gulp.task('watch', ['watchify','browserSync'], function(callback) {
-  gulp.watch(config.sass.src,   ['sass']);
-  gulp.watch(config.images.src, ['images']);
-  gulp.watch(config.markup.src, ['markup']);
+var watchTask = function(callback) {
+  gulp.watch(config.sass.src,   ['sass'])
+  gulp.watch(config.images.src, ['images'])
+  gulp.watch(config.markup.src, ['markup'])
   // Watchify will watch and recompile our JS, so no need to gulp.watch it
-});
+}
+
+gulp.task('watch', ['watchify','browserSync'], watchTask)
+module.exports = watchTask

--- a/gulp/tasks/watchify.js
+++ b/gulp/tasks/watchify.js
@@ -1,7 +1,10 @@
-var gulp           = require('gulp');
+var gulp           = require('gulp')
 var browserifyTask = require('./browserify')
 
-gulp.task('watchify', function(callback) {
+var watchifyTask = function(callback) {
   // Start browserify task with devMode === true
-  browserifyTask(callback, true);
-});
+  browserifyTask(callback, true)
+}
+
+gulp.task('watchify', watchifyTask)
+module.exports = watchifyTask


### PR DESCRIPTION
Lets you call tasks as functions. Useful when order matters.

```js

var task1 = require('./task1')
var task2 = require('./task2')
var task3 = require('./task3')

gulp.task('production', function() {
  task1()
  task2()
  task3()
})
```

Whereas the following would run all tasks concurrently
```js
gulp.task('production', ['task1', 'task2', 'task3']);
```