### PR TITLE
Update comment about watchify bug

### DIFF
--- a/gulp/tasks/browserify.js
+++ b/gulp/tasks/browserify.js
@@ -28,7 +28,8 @@ var browserifyTask = function(callback, devMode) {
       // Add watchify args and debug (sourcemaps) option
       _.extend(bundleConfig, watchify.args, { debug: true });
       // A watchify require/external bug that prevents proper recompiling,
-      // so (for now) we'll ignore these options during development
+      // so (for now) we'll ignore these options during development. Running
+      // `gulp browserify` directly will properly require and externalize.
       bundleConfig = _.omit(bundleConfig, ['external', 'require']);
     }
 


### PR DESCRIPTION
Correctly stated, there is a workaround as described in the commit message of the initial workaround. Why ever, not the full description for the workaround was provided, leave persons like me in the dark.

Added the missing workaround with using the Browserify task directly.