### PR TITLE
Use watchify task instead of browserify task in watch task

### DIFF
--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -1,11 +1,11 @@
 /* Notes:
-   - gulp/tasks/browserify.js handles js recompiling with watchify
+   - gulp/tasks/watchify.js handles js recompiling with watchify
    - gulp/tasks/browserSync.js watches and reloads compiled files
 */
 
 var gulp     = require('gulp');
 var config   = require('../config');
-var watchify = require('./browserify')
+var watchify = require('./watchify')
 
 gulp.task('watch', ['watchify','browserSync'], function(callback) {
   gulp.watch(config.sass.src,   ['sass']);


### PR DESCRIPTION
Browserify was not re bundling on updates sometimes. Figured this could be the reason.