### PR TITLE
[update] Upgrade babel

### DIFF
--- a/gulpfile.js/config/webpack.js
+++ b/gulpfile.js/config/webpack.js
@@ -30,7 +30,7 @@ module.exports = function(env) {
       loaders: [
         {
           test: /\.js$/,
-          loader: 'babel-loader?experimental',
+          loader: 'babel-loader?stage=1',
           exclude: /node_modules/
         }
       ]

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "test": "gulp build:production"
   },
   "dependencies": {
-    "babel-core": "^4.7.16",
-    "babel-loader": "^4.2.0",
-    "babelify": "^5.0.3",
+    "babel-core": "^5.0.x",
+    "babel-loader": "^5.0.x",
+    "babelify": "^6.0.x",
     "browser-sync": "^2.0.0",
     "del": "^1.1.1",
     "gulp": "^3.8.7",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "babel-core": "^5.0.x",
     "babel-loader": "^5.0.x",
-    "babelify": "^6.0.x",
     "browser-sync": "^2.0.0",
     "del": "^1.1.1",
     "gulp": "^3.8.7",


### PR DESCRIPTION
Upgrades Babel to 5.0

http://babeljs.io/blog/2015/03/31/5.0.0/

Side note: Is `babelify` needed anymore?