### PR TITLE
Remove .sass-cache folder from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .DS_Store
-.sass-cache
 build
 Desktop.ini
 node_modules


### PR DESCRIPTION
You're using LibSass in `gulp-sass`. Unlike Sass, LibSass doesn't create `.sass-cache` so it's no longer necessary to include it into `.gitignore`