### PR TITLE
Resolves karma issue so it will stop on test failures

### DIFF
--- a/gulpfile.js/tasks/karma.js
+++ b/gulpfile.js/tasks/karma.js
@@ -6,6 +6,9 @@ var karmaTask = function(done) {
     configFile: process.cwd() + '/karma.conf.js',
     singleRun: true
   }, function(exitStatus) {
+    // Karma's return status is not compatible with gulp's streams
+    // See: http://stackoverflow.com/questions/26614738/issue-running-karma-task-from-gulp
+    // or: https://github.com/gulpjs/gulp/issues/587 for more information
     done(exitStatus ? "There are failing unit tests" : undefined);
   });
 };

--- a/gulpfile.js/tasks/karma.js
+++ b/gulpfile.js/tasks/karma.js
@@ -5,7 +5,9 @@ var karmaTask = function(done) {
   karma.server.start({
     configFile: process.cwd() + '/karma.conf.js',
     singleRun: true
-  }, done);
+  }, function(exitStatus) {
+    done(exitStatus ? "There are failing unit tests" : undefined);
+  });
 };
 
 gulp.task('karma', karmaTask);


### PR DESCRIPTION
See: gulpjs/gulp#587 and [Issue running karma task from gulp](http://stackoverflow.com/questions/26614738/issue-running-karma-task-from-gulp) for more information on why this is needed.