### PR TITLE
remove ./ prefix for watch

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -1,5 +1,5 @@
-var dest = "./build";
-var src = './src';
+var dest = "build";
+var src = 'src';
 
 module.exports = {
   browserSync: {


### PR DESCRIPTION
Found that the ./ path prefix prevented new/deleted files from being picked up in gulp.watch. Confirmed by remove './' prefix, all good again and is equivalent.

https://github.com/floatdrop/gulp-watch/issues/1

Note: I just realized this issue with with gulp-watch, not gulp.watch which is where I noticed the problem. However, I did find that adding/removing files weren't picked up when my glob from config had the './' prefix.