### PR TITLE
Fix error in creating rev'd icon font first time

### DIFF
--- a/gulpfile.js/tasks/rev/rev-iconfont-workaround.js
+++ b/gulpfile.js/tasks/rev/rev-iconfont-workaround.js
@@ -44,7 +44,7 @@ gulp.task('rev-iconfont-workaround', ['rev-assets'], function() {
       manifest[file.path + ext] = file.path + file.hash + ext;
     });
 
-    return gulp.src(config.publicDirectory + '/' + file.path + '*.!(svg)')
+    return gulp.src(config.publicDirectory + '/' + file.path + '.!(svg)')
       .pipe(rename({suffix: file.hash}))
       .pipe(gulp.dest(iconConfig.dest));
   });


### PR DESCRIPTION
As mentioned by @mzlock in #149,  rev tasks fail the first time around with a clean public directory.

This change should fix that. The reason is file.path is set to something like `fonts/icons` and so the period limits the search to previously revved files, not the original.