### PR TITLE
Changes Swig to Nunjucks.

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -1,6 +1,7 @@
 {#
-  Swig Templating!
-  Docs: http://paularmstrong.github.io/swig/docs/
+  Nunjucks!
+  Homepage: https://mozilla.github.io/nunjucks/
+  Docs: https://mozilla.github.io/nunjucks/api.html
 #}
 
 {% extends 'layouts/application.html' %}

--- a/app/views/layouts/application.html
+++ b/app/views/layouts/application.html
@@ -10,7 +10,7 @@
   <h1>Gulp All The Things!</h1>
   {% block content %}{% endblock %}
   <p>Made with ♥ at <a href="http://viget.com">Viget</a></p>
-  {% include "../shared/page-nav.html" %}
+  {% include "/shared/page-nav.html" %}
   <script src="assets/javascripts/shared.js"></script>
   {% block javascript %}{% endblock %}
 </body>

--- a/app/views/page2.html
+++ b/app/views/page2.html
@@ -1,6 +1,7 @@
 {#
-  Swig Templating!
-  Docs: http://paularmstrong.github.io/swig/docs/
+  Nunjucks!
+  Homepage: https://mozilla.github.io/nunjucks/
+  Docs: https://mozilla.github.io/nunjucks/api.html
 #}
 
 {% extends 'layouts/application.html' %}

--- a/gulpfile.js/config/html.js
+++ b/gulpfile.js/config/html.js
@@ -4,7 +4,8 @@ module.exports = {
   watch: config.sourceDirectory + '/views/**/*.html',
   src: [config.sourceDirectory + '/views/**/*.html', '!**/{layouts,shared}/**'],
   dest: config.publicDirectory,
-  swig: {
-    defaults: { cache: false }
+  nunjucks: [config.sourceDirectory + '/views/'],
+  htmlmin: {
+    collapseWhitespace: true
   }
 }

--- a/gulpfile.js/tasks/html.js
+++ b/gulpfile.js/tasks/html.js
@@ -1,13 +1,21 @@
 var browserSync  = require('browser-sync');
 var config       = require('../config/html');
 var gulp         = require('gulp');
-var swig         = require('gulp-swig');
+var render       = require('gulp-nunjucks-render');
+var gulpif       = require('gulp-if');
+var htmlmin      = require('gulp-htmlmin');
 var handleErrors = require('../lib/handleErrors');
 
 gulp.task('html', function() {
+  render.nunjucks.configure(config.nunjucks, {
+    watch: false
+  });
   return gulp.src(config.src)
-    .pipe(swig(config.swig))
+    .pipe(render())
     .on('error', handleErrors)
+    .pipe(gulpif(process.env.NODE_ENV == 'production', htmlmin(config.htmlmin)))
     .pipe(gulp.dest(config.dest))
-    .pipe(browserSync.reload({stream:true}));
+    .pipe(browserSync.reload({
+      stream: true
+    }));
 });

--- a/package.json
+++ b/package.json
@@ -59,6 +59,9 @@
     "express": "^4.12.2",
     "gulp-gh-pages": "^0.4.0",
     "morgan": "^1.5.1",
-    "open": "0.0.5"
+    "open": "0.0.5",
+    "gulp-if": "~1.2.5",
+    "gulp-htmlmin": "~1.1.3",
+    "gulp-nunjucks-render": "~0.2.1"
   }
 }


### PR DESCRIPTION
Swig is no longer maintained, but Nunjucks is picking up steam.  Suggest moving to Nunjucks, which as you can see requires almost no changes.

Also, you might see a tiny preview of removing the build:production and build:development in favor of using gulp-if!

See more discussion at #154 and #97 