### PR TITLE
Fix icon/sprite css property

### DIFF
--- a/src/stylesheets/global.sass
+++ b/src/stylesheets/global.sass
@@ -10,7 +10,6 @@
 .icon
   font-size: 32px
   margin: 4px
-  text-align: center
 
   &.-instagram
     color: $dark-grey
@@ -27,7 +26,6 @@
   fill: currentColor
   margin: 8px
   width: 32px
-  text-align: center
 
   &.-instagram
     fill: $dark-grey

--- a/src/stylesheets/global.sass
+++ b/src/stylesheets/global.sass
@@ -10,7 +10,7 @@
 .icon
   font-size: 32px
   margin: 4px
-  text-align: middle
+  text-align: center
 
   &.-instagram
     color: $dark-grey
@@ -27,7 +27,7 @@
   fill: currentColor
   margin: 8px
   width: 32px
-  text-align: middle
+  text-align: center
 
   &.-instagram
     fill: $dark-grey


### PR DESCRIPTION
Text-align doesn't have a 'middle' property.

(Vertical-align does though, if that was intended instead..)