### PR TITLE
gulp-rev-napkin cleans up unhashed files after rev'ing

### DIFF
--- a/gulpfile.js/tasks/rev/rev-assets.js
+++ b/gulpfile.js/tasks/rev/rev-assets.js
@@ -1,7 +1,8 @@
-var config = require('../../config');
+var config         = require('../../config');
 var iconFontConfig = require('../../config/iconFont');
-var gulp   = require('gulp');
-var rev    = require('gulp-rev');
+var gulp           = require('gulp');
+var rev            = require('gulp-rev');
+var revNapkin      = require('gulp-rev-napkin');
 
 // 1) Add md5 hashes to assets referenced by CSS and JS files
 gulp.task('rev-assets', function() {
@@ -11,6 +12,7 @@ gulp.task('rev-assets', function() {
   return gulp.src([config.publicDirectory + '/**/*', notThese])
     .pipe(rev())
     .pipe(gulp.dest(config.publicDirectory))
+    .pipe(revNapkin({verbose: false}))
     .pipe(rev.manifest('public/rev-manifest.json', {merge: true}))
     .pipe(gulp.dest(''));
 });

--- a/gulpfile.js/tasks/rev/rev-css.js
+++ b/gulpfile.js/tasks/rev/rev-css.js
@@ -1,9 +1,10 @@
-var config = require('../../config');
-var filter = require('gulp-filter');
-var gulp   = require('gulp');
-var minify = require('gulp-minify-css');
-var rev    = require('gulp-rev');
-var uglify = require('gulp-uglify');
+var config    = require('../../config');
+var filter    = require('gulp-filter');
+var gulp      = require('gulp');
+var minify    = require('gulp-minify-css');
+var rev       = require('gulp-rev');
+var revNapkin = require('gulp-rev-napkin');
+var uglify    = require('gulp-uglify');
 
 // 4) Rev and compress CSS and JS files (this is done after assets, so that if a
 //    referenced asset hash changes, the parent hash will change as well
@@ -12,6 +13,7 @@ gulp.task('rev-css', function(){
     .pipe(rev())
     .pipe(minify())
     .pipe(gulp.dest(config.publicDirectory))
+    .pipe(revNapkin({verbose: false}))
     .pipe(rev.manifest('public/rev-manifest.json', {merge: true}))
     .pipe(gulp.dest(''));
 });

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "gulp-nunjucks-render": "^0.2.1",
     "gulp-rename": "^1.2.2",
     "gulp-rev": "^5.1.0",
+    "gulp-rev-napkin": "^0.1.0",
     "gulp-rev-replace": "^0.4.2",
     "gulp-sass": "^2.0.4",
     "gulp-sequence": "^0.4.0",


### PR DESCRIPTION
[gulp-rev-napkin](https://www.npmjs.com/package/gulp-rev-napkin) removes original files after they have been run through gulp-rev as mentioned in issue #147 
