### PR TITLE
Fix os tmp dir path in deploy config

### DIFF
--- a/gulpfile.js/config/deploy.js
+++ b/gulpfile.js/config/deploy.js
@@ -1,4 +1,5 @@
 var config = require('./')
+var path = require('path')
 var os = require('os')
 var project = require('../../package.json')
 
@@ -7,6 +8,6 @@ module.exports = {
   src: config.publicDirectory + '/**/*',
   ghPages: {
     // https://github.com/shinnn/gulp-gh-pages/issues/63
-    cacheDir: os.tmpdir() + project.name
+    cacheDir: path.join(os.tmpdir(),project.name)
   }
 }


### PR DESCRIPTION
On Ubuntu, the previous config actually created a folder named tmpPROJECTNAME rather than tmp/PROJECTNAME.

![screenshot from 2015-07-30 13 42 21](https://cloud.githubusercontent.com/assets/5353151/8975441/c08e773c-36c1-11e5-9f67-88e37ced1056.png)

Using path fixed this for me, and I think would work equally across win/mac/linux.
I've only tested on linux, but path is standardized as far as I'm aware.